### PR TITLE
Feat/modal

### DIFF
--- a/src/_components/modal/Modal.tsx
+++ b/src/_components/modal/Modal.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+type ModalProps = {
+  modalType?: string; // modalType의 경우 이후 컨펌이나 다른 타입이 추가될 때 다르게 ui 보여줄 수 있도록 적용 예정
+  className?: string;
+  width: string;
+  isOpen: boolean;
+  children: React.ReactNode;
+  onClose: () => void;
+};
+
+const Modal = ({
+  modalType,
+  className,
+  width,
+  children,
+  isOpen,
+  onClose
+}: ModalProps) => {
+  if (!isOpen) return null;
+  return (
+    <div
+      className={`modal fixed left-0 top-0 h-full w-full bg-[rgba(0,0,0,.35)] ${className ? className : ""} flex items-center justify-center`}
+    >
+      <div className={`modal_cont`} style={{ width: `${width}px` }}>
+        <div className="modal_inner">{children}</div>
+        <button type="button" className="modal_close_btn" onClick={onClose}>
+          닫기
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/src/app/(test)/modal-test/page.tsx
+++ b/src/app/(test)/modal-test/page.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import Modal from "@/_components/modal/Modal";
+import { useState } from "react";
+const ModalTestPage = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleModalOpen = () => setIsOpen(true);
+  const handleModalClose = () => setIsOpen(false);
+
+  return (
+    <div>
+      <h1>모달 테스트</h1>
+      <button type="button" className="modal_btn" onClick={handleModalOpen}>
+        모달 열기
+      </button>
+
+      <Modal
+        modalType={""} // 모달 타입
+        width={"500"} // 컨텐츠 넓이
+        isOpen={isOpen}
+        onClose={handleModalClose}
+      >
+        <h2>모달 내용</h2>
+        <p>모달 내의 텍스트입니다.</p>
+      </Modal>
+    </div>
+  );
+};
+
+export default ModalTestPage;


### PR DESCRIPTION
## [1차] 모달 공통 UI 기능 적용

> 버튼 클릭 시 fixed로 노출되는 모달 공통 레이아웃 기능 적용

## 작업 상세 내용

1.  `_components/modal/Modal.tsx`
모달 공통 ui 컴포넌트 입니다. props로는  modalType, wid, children, isOpen, onClose 값을 전달 받습니다.
- `modalType`: 모달 타입입니다. 클래스로 사용할 수 있고, 조건 처리하여 다른 ui를 노출하기위해 적용했습니다.
- `wid`: 모달 컨텐츠 넓이값 입니다.
- `children`: 모달에 어떠한 값이 들어가도 css처리된 값이 보여지도록 children으로 적용했습니다.
- `isOpen`: useState를 통해 모달의 상태(block,none)가 변경되도록 설정했습니다.
- `onClose` : useState를 false변경해서 모달창을 닫아주는 함수입니다.


2. _components/modal/ModalButton.tsx
모달 버튼 컴포넌트입니다. props로는 onClick, buttonText 값을 전달 받습니다.
- `onClick` : 상위 컴포넌트에서 `isOpen` 상태값을 true로 변경해주는 함수를 전달받습니다.
- `buttonText` :  버튼 텍스트를 전달받습니다. 해당 props로 조건부 처리하여, 이미지가 있는 버튼과 텍스트만 있는 버튼 처리를 할 수 있습니다.

3. app/(test)/modal/page.tsx
모달 테스트 페이지입니다. 해당 페이지는 CSR 로 되어있으며, useState의 상태값을 통해 모달 컴포넌트를 제어합니다.


## 기타사항
현재 디자인,와이어 프레임이 확정 되어있지 않아서 1차로 기능만 적용했습니다. 마이페이지에서도 모달이 사용도리 것 같아서 1차 작업내용으로 PR 올렸습니다. 추후 모달의 타입과 디자인에 따라 반영할 수 있도록 하겠습니다.

## 참고할만한 자료(선택)
설재혁 튜터님 피드백
1. 기존 modalType으로 전달받아 className에 적용햇는데 당시에 modal 타입이 어떤게 있는지 몰라서 modalType하나로 className과 조건처리를 하려했습니다. 하지만 className용도에는 맞지 않아서 className props를 추가했습니다.
2. 공통 컴포넌트에 들어가는 props의 naming은 명확하게 하는게 좋다고 해주셔서, 기존의 props중 wid => width로 변경했습니다.
3. 닫기 버튼으로 모달을 닫는거 이외에 외부를 클릭해도 닫는 처리를 말씀 주셨는데, 이후 타입 작업하면서 적용할 예정입니다. (`dimmed` 키워드 참고)
4. 모달이 켜져있을 때 뒤쪽 컨텐츠에 상호작용이 안되도록 추가적인 처리 또한 2차 작업하면서 적용하겠습니다! 