### PR TITLE
Feat/camp

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    domains: ["gocamping.or.kr"]
+  }
+};
 
 export default nextConfig;

--- a/src/_components/camp/CampCard.tsx
+++ b/src/_components/camp/CampCard.tsx
@@ -1,0 +1,40 @@
+import { Camp } from "@/app/(pages)/camps/types/Camp";
+import Image from "next/image";
+import Link from "next/link";
+
+type CampingDataProps = {
+  camp: Camp;
+};
+
+const CampCard = ({ camp }: CampingDataProps) => {
+  return (
+    <div className="camping_card group w-[calc(25%-30px)]">
+      <Link href={`/camps/${camp.contentId}`}>
+        <div className="inner">
+          <div className="img_box relative overflow-hidden py-[23%]">
+            <Image
+              src={camp.firstImageUrl}
+              className="full h-full transform transition-all duration-500 ease-in-out group-hover:scale-110"
+              layout="fill"
+              alt={camp.facltNm}
+            />
+            <span>{camp.doNm}</span>
+          </div>
+          <h2 className="text-[20px]">{camp.facltNm}</h2>
+          <div className="tag">{camp.sbrsEtc}</div>
+          <div className="info">
+            <p>{camp.addr1}</p>
+            <p>249Km</p>
+            <p>
+              <span>{camp.induty}</span>
+              <span>파쇄석</span>
+              <span>20도 맑음</span>
+            </p>
+          </div>
+        </div>
+      </Link>
+    </div>
+  );
+};
+
+export default CampCard;

--- a/src/_components/camp/CampDetail.tsx
+++ b/src/_components/camp/CampDetail.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { Camp } from "@/app/(pages)/camps/types/Camp";
+
+type CampDetailProps = {
+  camp: Camp;
+};
+
+const CampDetail = ({ camp }: CampDetailProps) => {
+  console.log(camp);
+
+  const nearbyInfo: string[] = camp.posblFcltyCl.split(",");
+
+  return (
+    <div className="camp_detail">
+      <div className="inner">
+        {/* 캠핑장 상세 최상단 */}
+        <div className="detail_section">
+          <div className="left_area">슬라이드 영역</div>
+          <div className="right_area">
+            <div className="info">
+              <div className="cont">
+                <h1>{camp.facltNm}</h1>
+                <p>{camp.addr1}</p>
+                <p>
+                  <span>20.5℃ 맑음</span>
+                  <span>249Km</span>
+                </p>
+                <ul>
+                  <li>#파쇄석 바닥</li>
+                  <li>#사진 맛집</li>
+                  <li>#프라이빗</li>
+                  <li>#야경이 예쁜</li>
+                  <li>#반려견 동반</li>
+                </ul>
+              </div>
+              <div className="btn_area">
+                <button>스크랩</button>
+                <button>공유하기</button>
+              </div>
+            </div>
+          </div>
+        </div>
+        {/* 캠핑장 상세 최상단*/}
+
+        {/* 캠핑장 소개 */}
+        <div className="detail_section mt-[60px]">
+          <h2 className="text-[36px] font-bold">캠핑장 소개</h2>
+          <p>{camp.featureNm ? camp.featureNm : camp.intro}</p>
+        </div>
+        {/*// 캠핑장 소개 */}
+
+        {/* 주변 정보 */}
+        <div className="detail_section mt-[60px]">
+          <h2 className="text-[36px] font-bold">주변 정보</h2>
+          <ul>
+            {nearbyInfo.map((item) => {
+              return <li key={item}>{item}</li>;
+            })}
+          </ul>
+        </div>
+        {/*// 주변 정보 */}
+
+        {/* 캠핑장 위치 */}
+        <div className="detail_section mt-[60px]">
+          <h2 className="text-[36px] font-bold">캠핑장 위치</h2>
+        </div>
+        {/*// 캠핑장 위치 */}
+
+        {/* 캠핑장 날씨를 알려드려요 */}
+        <div className="detail_section mt-[60px]">
+          <h2 className="text-[36px] font-bold">캠핑장 날씨를 알려드려요</h2>
+        </div>
+        {/*// 캠핑장 날씨를 알려드려요 */}
+
+        {/* 캠핑장 리뷰 */}
+        <div className="detail_section mt-[60px]">
+          <h2 className="text-[36px] font-bold">캠핑장 리뷰</h2>
+        </div>
+        {/*// 캠핑장 리뷰 */}
+
+        {/* 댓글 쓰기 */}
+        <div className="detail_section mt-[60px]">
+          <h2 className="text-[36px] font-bold">댓글 쓰기</h2>
+        </div>
+        {/*// 댓글 쓰기 */}
+
+        {/* 이 장소와 함께 봤어요 */}
+        <div className="detail_section mt-[60px]">
+          <h2 className="text-[36px] font-bold">이 장소와 함께 봤어요</h2>
+        </div>
+        {/*// 이 장소와 함께 봤어요 */}
+      </div>
+    </div>
+  );
+};
+
+export default CampDetail;

--- a/src/_components/camp/CampList.tsx
+++ b/src/_components/camp/CampList.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import CampCard from "@/_components/camp/CampCard";
+import { Camp } from "@/app/(pages)/camps/types/Camp";
+
+type CampListProps = {
+  camps: Camp[];
+};
+
+// CampList 컴포넌트가 서버 컴포넌트로 정의된 경우
+const CampList = ({ camps }: CampListProps) => {
+  return (
+    <div className="camp_list">
+      <div className="list_box flex flex-wrap gap-[30px]">
+        {camps.map((camp) => (
+          <CampCard key={camp.contentId} camp={camp} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default CampList;

--- a/src/_utils/api/apiKey.ts
+++ b/src/_utils/api/apiKey.ts
@@ -1,0 +1,3 @@
+export const GOAMPING_URL =
+  "http://apis.data.go.kr/B551011/GoCamping/basedList";
+export const GOAMPING_KEY = process.env.NEXT_PUBLIC_GOCAMPING_KEY;

--- a/src/_utils/serverActions/campApi.ts
+++ b/src/_utils/serverActions/campApi.ts
@@ -1,0 +1,57 @@
+"use server";
+
+import { CampApiResponse } from "@/app/(pages)/camps/types/Camp";
+import { GOAMPING_KEY, GOAMPING_URL } from "../api/apiKey";
+
+export const getTotalData = async () => {
+  try {
+    const res = await fetch(
+      `${GOAMPING_URL}?serviceKey=${GOAMPING_KEY}&numOfRows=4041&pageNo=max&MobileOS=ETC&MobileApp=TestApp&_type=json`,
+      {
+        next: {
+          revalidate: 86400
+        }
+      }
+    );
+
+    if (!res.ok) {
+      throw new Error(`HTTP error! status: ${res.status}`);
+    }
+
+    const data: CampApiResponse = await res.json();
+    return data.response.body.items.item;
+  } catch (error) {
+    console.error("Error fetching data:", error);
+    return null;
+  }
+};
+
+export const getCampData = async (contentId: string) => {
+  try {
+    const res = await fetch(
+      `${GOAMPING_URL}?serviceKey=${GOAMPING_KEY}&numOfRows=4000&pageNo=1&MobileOS=ETC&MobileApp=TestApp&_type=json`,
+      {
+        next: {
+          revalidate: 86400
+        }
+      }
+    );
+
+    if (!res.ok) {
+      throw new Error(`HTTP error! status: ${res.status}`);
+    }
+
+    const data: CampApiResponse = await res.json();
+    console.log("API Response:", data);
+
+    // contentId에 맞는 캠프 데이터 찾기
+    const camp = data.response.body.items.item.find(
+      (item) => item.contentId === contentId
+    );
+
+    return camp || null;
+  } catch (error) {
+    console.error("Error fetching data:", error);
+    return null;
+  }
+};

--- a/src/app/(pages)/camps/[campId]/page.tsx
+++ b/src/app/(pages)/camps/[campId]/page.tsx
@@ -1,7 +1,18 @@
+import CampDetail from "@/_components/camp/CampDetail";
+import { getCampData } from "@/_utils/serverActions/campApi";
 import React from "react";
 
-const CampDetail = () => {
-  return <div>CampDetail</div>;
+type CampDetailProps = {
+  params: {
+    campId: string;
+  };
 };
 
-export default CampDetail;
+const CampDetailPage = async ({ params }: CampDetailProps) => {
+  const camp = await getCampData(params.campId);
+
+  if (!camp) return <div>캠프 데이터를 찾을 수 없습니다.</div>;
+
+  return <CampDetail camp={camp} />;
+};
+export default CampDetailPage;

--- a/src/app/(pages)/camps/page.tsx
+++ b/src/app/(pages)/camps/page.tsx
@@ -1,7 +1,12 @@
-import React from "react";
+import CampList from "@/_components/camp/CampList";
+import { getTotalData } from "@/_utils/serverActions/campApi";
 
-const Camps = () => {
-  return <div>Camps</div>;
+const CampListPage = async () => {
+  const camps = await getTotalData();
+
+  if (!camps) return <div>데이터가 없음</div>;
+
+  return <CampList camps={camps} />;
 };
 
-export default Camps;
+export default CampListPage;

--- a/src/app/(pages)/camps/types/Camp.ts
+++ b/src/app/(pages)/camps/types/Camp.ts
@@ -1,0 +1,95 @@
+// Camp.ts
+export interface Camp {
+  contentId: string;
+  facltNm: string;
+  lineIntro: string;
+  intro: string;
+  allar: string;
+  insrncAt: string;
+  trsagntNo: string;
+  bizrno: string;
+  facltDivNm: string;
+  mangeDivNm: string;
+  mgcDiv: string;
+  manageSttus: string;
+  hvofBgnde: string;
+  hvofEnddle: string;
+  featureNm: string;
+  induty: string;
+  lctCl: string;
+  doNm: string;
+  sigunguNm: string;
+  zipcode: string;
+  addr1: string;
+  addr2: string;
+  mapX: string;
+  mapY: string;
+  direction: string;
+  tel: string;
+  homepage: string;
+  resveUrl: string;
+  resveCl: string;
+  manageNmpr: string;
+  gnrlSiteCo: string;
+  autoSiteCo: string;
+  glampSiteCo: string;
+  caravSiteCo: string;
+  indvdlCaravSiteCo: string;
+  sitedStnc: string;
+  siteMg1Width: string;
+  siteMg2Width: string;
+  siteMg3Width: string;
+  siteMg1Vrticl: string;
+  siteMg2Vrticl: string;
+  siteMg3Vrticl: string;
+  siteMg1Co: string;
+  siteMg2Co: string;
+  siteMg3Co: string;
+  siteBottomCl1: string;
+  siteBottomCl2: string;
+  siteBottomCl3: string;
+  siteBottomCl4: string;
+  siteBottomCl5: string;
+  tooltip: string;
+  glampInnerFclty: string;
+  caravInnerFclty: string;
+  prmisnDe: string;
+  operPdCl: string;
+  operDeCl: string;
+  trlerAcmpnyAt: string;
+  caravAcmpnyAt: string;
+  toiletCo: string;
+  swrmCo: string;
+  wtrplCo: string;
+  brazierCl: string;
+  sbrsCl: string;
+  sbrsEtc: string;
+  posblFcltyCl: string;
+  posblFcltyEtc: string;
+  clturEventAt: string;
+  clturEvent: string;
+  exprnProgrmAt: string;
+  exprnProgrm: string;
+  extshrCo: string;
+  frprvtWrppCo: string;
+  frprvtSandCo: string;
+  fireSensorCo: string;
+  themaEnvrnCl: string;
+  eqpmnLendCl: string;
+  animalCmgCl: string;
+  tourEraCl: string;
+  firstImageUrl: string;
+  createdtime: string;
+  modifiedtime: string;
+}
+
+export interface CampApiResponse {
+  response: {
+    body: {
+      items: {
+        item: Camp[];
+      };
+      totalCount: number;
+    };
+  };
+}


### PR DESCRIPTION
## Camp List, Card, Detail 적용

## 작업 상세 내용

1. api key 값 추가
2. camp server action 추가 (전체 챔피언, 상세페이지 챔피언)
3. _components/camp 위치에 List, Card, Detail 컴포넌트 추가
4. http://localhost:3000/camps 에서 리스트,카드,상세 확인 가능합니다.

## 기타사항
캠프 관련 1차 작업 완료된 상태입니다.

[대기중인 작업]
- 리스트 필터 작업 필요
- 카드 와이어프레임 확정되면 맞춰서 작업 필요
- 상세페이지 슬라이드 및 스크랩,공유하기 작업 필요
- 작성하기 컴포넌트 및 페이지 작업 필요 (와이어프레임 없음)

## 참고할만한 자료(선택)
- 없습니다.
