### PR TITLE
[Feat/search] : 검색 기능 개선 및 컴포넌트 구조 정리

### DIFF
--- a/src/_components/main/MainSearch.tsx
+++ b/src/_components/main/MainSearch.tsx
@@ -6,20 +6,20 @@ const MainSearch = () => {
   return (
     <div className="mt-10 flex flex-col items-center">
       <ul className="flex gap-5">
-        <Link href={"./search/"}>
-          <li>#캠핑여행</li>
+        <Link href={"./search?campingTypes=일반야영장"}>
+          <li>#캠핑</li>
         </Link>
-        <Link href={"./"}>
+        <Link href={"./search?campingTypes=자동차야영장"}>
           <li>#차박</li>
         </Link>
-        <Link href={"./"}>
-          <li>#오토캠핑</li>
-        </Link>
-        <Link href={"./"}>
+        <Link href={"./search?campingTypes=글램핑"}>
           <li>#글램핑</li>
         </Link>
-        <Link href={"./"}>
+        <Link href={"./search?amenities=내부화장실"}>
           <li>#내부화장실</li>
+        </Link>
+        <Link href={"./search?petOption=가능"}>
+          <li>#애견동반 가능</li>
         </Link>
       </ul>
       <div className="mt-[14px] w-full max-w-[800px] flex-1">

--- a/src/_components/search/dropdown/DropDownSearch.tsx
+++ b/src/_components/search/dropdown/DropDownSearch.tsx
@@ -20,7 +20,7 @@ const DropDownSearch: React.FC<{
         {results?.length > 0 ? (
           results.map((camp) => (
             <Link
-              href={`camps/${camp.contentId}`}
+              href={`camp-detail/${camp.contentId}`}
               onClick={closeDropdown}
               key={camp.contentId}
             >

--- a/src/app/(pages)/search/components/SearchHeader.tsx
+++ b/src/app/(pages)/search/components/SearchHeader.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { FilterSelect } from "./filter/FilterSelect";
+import { REGIONS } from "@/_utils/regions";
+import SearchBar from "@/_components/search/searchBar/SearchBar";
+import {
+  AMENITIES,
+  CAMPING_TYPES,
+  FACILITIES_OPTIONS,
+  GROUND_TYPES,
+  PET_OPTIONS
+} from "../constants/filterOptions";
+import { FilterState } from "../types/filters";
+
+interface SearchHeaderProps {
+  filters: FilterState;
+  handleUpdateFilter: (key: "region" | "petOption", value: string) => void;
+  handleToggleArrayFilter: (
+    key: "facilities" | "campingTypes" | "amenities" | "groundTypes",
+    value: string
+  ) => void;
+}
+const SearchHeader = ({
+  filters,
+  handleUpdateFilter,
+  handleToggleArrayFilter
+}: SearchHeaderProps) => {
+  return (
+    <div className="flex-shrink-0 border-b p-4">
+      <SearchBar variant="search" />
+      <div className="my-7 flex flex-wrap gap-2">
+        <FilterSelect
+          value={filters.region}
+          options={REGIONS}
+          placeholder="지역"
+          onChange={(value) => handleUpdateFilter("region", value)}
+        />
+        <FilterSelect
+          value={filters.petOption}
+          options={PET_OPTIONS}
+          placeholder="반려동물"
+          onChange={(value) => handleUpdateFilter("petOption", value)}
+        />
+        <FilterSelect
+          value={filters.facilities}
+          options={FACILITIES_OPTIONS}
+          placeholder="부대시설"
+          onChange={(value) => handleToggleArrayFilter("facilities", value)}
+          isMulti
+        />
+        <FilterSelect
+          value={filters.campingTypes}
+          options={CAMPING_TYPES}
+          placeholder="종류"
+          onChange={(value) => handleToggleArrayFilter("campingTypes", value)}
+          isMulti
+        />
+        <FilterSelect
+          value={filters.amenities}
+          options={AMENITIES}
+          placeholder="편의시설"
+          onChange={(value) => handleToggleArrayFilter("amenities", value)}
+          isMulti
+        />
+        <FilterSelect
+          value={filters.groundTypes}
+          options={GROUND_TYPES}
+          placeholder="사이트"
+          onChange={(value) => handleToggleArrayFilter("groundTypes", value)}
+          isMulti
+        />
+      </div>
+    </div>
+  );
+};
+
+export default SearchHeader;

--- a/src/app/(pages)/search/components/SearchList.tsx
+++ b/src/app/(pages)/search/components/SearchList.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { Camp } from "../../camps/types/Camp";
+import { CampCard } from "./CampCard";
+
+interface SearchListProps {
+  filteredCamps: Camp[];
+  handleCampSelect: (camp: Camp) => void;
+}
+const SearchList = ({ filteredCamps, handleCampSelect }: SearchListProps) => {
+  return (
+    <div className="flex-1 overflow-y-auto">
+      <div className="p-4">
+        <h2 className="mb-4 text-xl font-bold">
+          검색결과 ({filteredCamps.length})
+        </h2>
+        <div className="space-y-4">
+          {filteredCamps.length > 0 ? (
+            filteredCamps.map((camp) => (
+              <CampCard
+                key={camp.contentId}
+                camp={camp}
+                onSelect={handleCampSelect}
+              />
+            ))
+          ) : (
+            <div className="py-8 text-center text-gray-500">
+              검색 결과가 없습니다.
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SearchList;

--- a/src/app/(pages)/search/components/SearchResults.tsx
+++ b/src/app/(pages)/search/components/SearchResults.tsx
@@ -1,7 +1,6 @@
 import SearchBar from "@/_components/search/searchBar/SearchBar";
 import { Camp } from "../../camps/types/Camp";
 import { useMap } from "../hooks/useSearchMap";
-import { FilterState } from "../types/filters";
 import { FilterSelect } from "./filter/FilterSelect";
 import {
   AMENITIES,
@@ -14,99 +13,41 @@ import { REGIONS } from "@/_utils/regions";
 import { CampCard } from "./CampCard";
 import { ActiveFilters } from "./filter/ActiveFilters";
 import { useFilters } from "../hooks/useFilters";
+import SearchHeader from "./SearchHeader";
+import SearchList from "./SearchList";
 
-export interface SearchResultsProps {
+interface SearchResultsProps {
   camps: Camp[];
 }
 export const SearchResults: React.FC<SearchResultsProps> = ({ camps }) => {
-  const { filters, filteredCamps, updateFilter, toggleArrayFilter } =
-    useFilters(camps);
+  const {
+    filters,
+    filteredCamps,
+    handleUpdateFilter,
+    handleToggleArrayFilter,
+    handleRemoveFilter
+  } = useFilters(camps);
+
   const { moveToMarker } = useMap(filteredCamps);
 
   const handleCampSelect = (selectedCamp: Camp) => {
     moveToMarker(selectedCamp);
   };
-
-  const handleRemoveFilter = (key: keyof FilterState, value?: string) => {
-    if (value) {
-      toggleArrayFilter(key, value);
-    } else {
-      updateFilter(key, Array.isArray(filters[key]) ? [] : "");
-    }
-  };
-
   return (
     <div className="flex h-screen w-[400px] flex-col border-r">
-      <div className="flex-shrink-0 border-b p-4">
-        <SearchBar variant="search" />
-        <div className="my-7 flex flex-wrap gap-2">
-          <FilterSelect
-            value={filters.region}
-            options={REGIONS}
-            placeholder="지역"
-            onChange={(value) => updateFilter("region", value)}
-          />
-          <FilterSelect
-            value={filters.petOption}
-            options={PET_OPTIONS}
-            placeholder="반려동물"
-            onChange={(value) => updateFilter("petOption", value)}
-          />
-          <FilterSelect
-            value={filters.facilities}
-            options={FACILITIES_OPTIONS}
-            placeholder="부대시설"
-            onChange={(value) => toggleArrayFilter("facilities", value)}
-            isMulti
-          />
-          <FilterSelect
-            value={filters.campingTypes}
-            options={CAMPING_TYPES}
-            placeholder="종류"
-            onChange={(value) => toggleArrayFilter("campingTypes", value)}
-            isMulti
-          />
-          <FilterSelect
-            value={filters.amenities}
-            options={AMENITIES}
-            placeholder="편의시설"
-            onChange={(value) => toggleArrayFilter("amenities", value)}
-            isMulti
-          />
-          <FilterSelect
-            value={filters.groundTypes}
-            options={GROUND_TYPES}
-            placeholder="사이트"
-            onChange={(value) => toggleArrayFilter("groundTypes", value)}
-            isMulti
-          />
-        </div>
-      </div>
-
+      {/* 검색 및 필터 */}
+      <SearchHeader
+        filters={filters}
+        handleUpdateFilter={handleUpdateFilter}
+        handleToggleArrayFilter={handleToggleArrayFilter}
+      />
+      {/* 적용된 필터 부분 */}
       <ActiveFilters filters={filters} onRemove={handleRemoveFilter} />
-
-      <div className="flex-1 overflow-y-auto">
-        <div className="p-4">
-          <h2 className="mb-4 text-xl font-bold">
-            검색결과 ({filteredCamps.length})
-          </h2>
-          <div className="space-y-4">
-            {filteredCamps.length > 0 ? (
-              filteredCamps.map((camp) => (
-                <CampCard
-                  key={camp.contentId}
-                  camp={camp}
-                  onSelect={handleCampSelect}
-                />
-              ))
-            ) : (
-              <div className="py-8 text-center text-gray-500">
-                검색 결과가 없습니다.
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
+      {/* 검색 결과 */}
+      <SearchList
+        filteredCamps={filteredCamps}
+        handleCampSelect={handleCampSelect}
+      />
     </div>
   );
 };

--- a/src/app/(pages)/search/hooks/useFilters.ts
+++ b/src/app/(pages)/search/hooks/useFilters.ts
@@ -1,89 +1,123 @@
-import { useState, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { Camp } from "../../camps/types/Camp";
 import { FilterState } from "../types/filters";
 
 export const useFilters = (camps: Camp[]) => {
-  const [filters, setFilters] = useState<FilterState>({
-    region: "",
-    petOption: "",
-    facilities: [],
-    campingTypes: [],
-    amenities: [],
-    groundTypes: []
-  });
+  const router = useRouter();
+  const searchParams = useSearchParams();
 
-  const [filteredCamps, setFilteredCamps] = useState<Camp[]>(camps);
-
-  useEffect(() => {
-    let result = camps;
-
-    if (filters.region && filters.region !== "전국") {
-      result = result.filter((camp) => camp.doNm === filters.region);
-    }
-
-    if (filters.petOption) {
-      result = result.filter((camp) => camp.animalCmgCl === filters.petOption);
-    }
-
-    if (filters.facilities.length > 0) {
-      result = result.filter((camp) =>
-        filters.facilities.every((facility) => camp.sbrsCl?.includes(facility))
-      );
-    }
-
-    if (filters.campingTypes.length > 0) {
-      result = result.filter((camp) =>
-        filters.campingTypes.every((type) => camp.induty?.includes(type))
-      );
-    }
-
-    if (filters.amenities.length > 0) {
-      result = result.filter((camp) =>
-        filters.amenities.every(
-          (amenity) =>
-            camp.glampInnerFclty?.includes(amenity) ||
-            camp.caravInnerFclty?.includes(amenity)
-        )
-      );
-    }
-
-    if (filters.groundTypes.length > 0) {
-      result = result.filter((camp) =>
-        filters.groundTypes.every((type) => {
-          const bottomTypes = {
-            잔디: camp.siteBottomCl1,
-            파쇄석: camp.siteBottomCl2,
-            데크: camp.siteBottomCl3,
-            자갈: camp.siteBottomCl4,
-            맨흙: camp.siteBottomCl5
-          };
-          return Number(bottomTypes[type as keyof typeof bottomTypes]) > 0;
-        })
-      );
-    }
-
-    setFilteredCamps(result);
-  }, [camps, filters]);
-
-  const updateFilter = (key: keyof FilterState, value: string | string[]) => {
-    setFilters((prev) => ({ ...prev, [key]: value }));
+  // URL에서 필터 상태 가져오기
+  const filters: FilterState = {
+    region: searchParams.get("region") || "",
+    petOption: searchParams.get("petOption") || "",
+    facilities: searchParams.getAll("facilities"),
+    campingTypes: searchParams.getAll("campingTypes"),
+    amenities: searchParams.getAll("amenities"),
+    groundTypes: searchParams.getAll("groundTypes")
   };
 
-  const toggleArrayFilter = (key: keyof FilterState, value: string) => {
-    if (!Array.isArray(filters[key])) return;
+  // 필터링 로직
+  const filteredCamps = camps.filter((camp) => {
+    if (
+      filters.region &&
+      filters.region !== "전국" &&
+      camp.doNm !== filters.region
+    )
+      return false;
 
-    const currentArray = filters[key] as string[];
-    const newArray = currentArray.includes(value)
-      ? currentArray.filter((item) => item !== value)
-      : [...currentArray, value];
+    if (filters.petOption && camp.animalCmgCl !== filters.petOption)
+      return false;
 
-    updateFilter(key, newArray);
+    if (
+      filters.facilities.length &&
+      !filters.facilities.every((f) => camp.sbrsCl.includes(f))
+    )
+      return false;
+
+    if (
+      filters.campingTypes.length &&
+      !filters.campingTypes.some((t) => camp.induty.includes(t))
+    )
+      return false;
+
+    if (
+      filters.amenities.length &&
+      !filters.amenities.every((a) => camp.glampInnerFclty.includes(a))
+    )
+      return false;
+
+    if (filters.groundTypes.length > 0) {
+      return filters.groundTypes.every((type) => {
+        const bottomTypes = {
+          잔디: camp.siteBottomCl1,
+          파쇄석: camp.siteBottomCl2,
+          데크: camp.siteBottomCl3,
+          자갈: camp.siteBottomCl4,
+          맨흙: camp.siteBottomCl5
+        };
+        return Number(bottomTypes[type as keyof typeof bottomTypes]) > 0;
+      });
+    }
+
+    return true;
+  });
+
+  const updateUrlParams = (newFilters: FilterState) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    Object.entries(newFilters).forEach(([key, value]) => {
+      params.delete(key);
+      if (Array.isArray(value)) {
+        value.forEach((v) => {
+          if (v) params.append(key, v);
+        });
+      } else if (value) {
+        params.set(key, value);
+      }
+    });
+
+    router.push(`?${params.toString()}`);
+  };
+
+  const handleUpdateFilter = (key: "region" | "petOption", value: string) => {
+    const newFilters = { ...filters };
+    newFilters[key] = value;
+    updateUrlParams(newFilters);
+  };
+
+  const handleToggleArrayFilter = (
+    key: "facilities" | "campingTypes" | "amenities" | "groundTypes",
+    value: string
+  ) => {
+    const currentValues = filters[key];
+    const newValues = currentValues.includes(value)
+      ? currentValues.filter((v) => v !== value)
+      : [...currentValues, value];
+
+    const newFilters = { ...filters };
+    newFilters[key] = newValues;
+    updateUrlParams(newFilters);
+  };
+
+  const handleRemoveFilter = (key: keyof FilterState, value?: string) => {
+    const newFilters = { ...filters };
+    if (key === "region" || key === "petOption") {
+      newFilters[key] = "";
+    } else {
+      if (value) {
+        newFilters[key] = filters[key].filter((v) => v !== value);
+      } else {
+        newFilters[key] = [];
+      }
+    }
+    updateUrlParams(newFilters);
   };
 
   return {
     filters,
     filteredCamps,
-    updateFilter,
-    toggleArrayFilter
+    handleUpdateFilter,
+    handleToggleArrayFilter,
+    handleRemoveFilter
   };
 };


### PR DESCRIPTION
## 어떤 기능인가요?

> 메인 태그와 검색 필터 URL 연동 및 컴포넌트 구조 개선

## 이슈 번호
- #46 

## 작업 상세 내용
### 1. URL 파라미터 연동
- 기존 state로 관리하던 필터링 옵션을 URL 파라미터로 관리하도록 변경
- 메인 페이지 태그(#글램핑 #카라반 #애견동반) 클릭 시 해당 필터가 적용된 검색 결과로 이동

### 2. 컴포넌트 구조 개선
- `SearchResults` 컴포넌트를 `SearchHeader`와 `SearchList`로 분리

### 3. 링크 연결 수정
- 검색 드롭다운의 캠핑장 상세 페이지 링크 경로 수정
  - `camps/${camp.contentId}` → `camp-detail/${camp.contentId}`
- 메인 페이지 해시태그 링크 연결