### PR TITLE
[Feat/map] 모임 상세페이지에 지도 구현

### DIFF
--- a/src/app/(pages)/meets/components/meetsDetail/MeetDetailController.tsx
+++ b/src/app/(pages)/meets/components/meetsDetail/MeetDetailController.tsx
@@ -6,13 +6,15 @@ import MeetIntroSection from "./MeetIntroSection";
 import MeetSuppliesSection from "./MeetSuppliesSection";
 import MeetRecommendSection from "./MeetRecommendSection";
 import useMeetDetailController from "../../hooks/useMeetDetailController";
+import DetailMap from "@/app/(pages)/camp-detail/components/DetailMap";
+import { Camp } from "@/app/(pages)/camps/types/Camp";
 
 type Props = {
   meetWithCamp: MeetWithCamp;
 };
 const MeetDetailController = ({ meetWithCamp }: Props) => {
   const { buttonConfig, hasChatAccess } = useMeetDetailController(meetWithCamp);
-
+  const camp = meetWithCamp.camp as unknown as Camp;
   return (
     <div className="mx-auto w-full max-w-[1360px] pl-[30px] pr-[30px]">
       <MeetTitleSection
@@ -23,6 +25,7 @@ const MeetDetailController = ({ meetWithCamp }: Props) => {
       <MeetIntroSection meetWithCamp={meetWithCamp} />
       <MeetContentSection meetWithCamp={meetWithCamp} />
       <MeetSuppliesSection meetWithCamp={meetWithCamp} />
+      <DetailMap camp={camp} />
       <MeetRecommendSection />
     </div>
   );

--- a/src/app/(pages)/search/components/SearchResults.tsx
+++ b/src/app/(pages)/search/components/SearchResults.tsx
@@ -1,16 +1,5 @@
-import SearchBar from "@/_components/search/searchBar/SearchBar";
 import { Camp } from "../../camps/types/Camp";
 import { useMap } from "../hooks/useSearchMap";
-import { FilterSelect } from "./filter/FilterSelect";
-import {
-  AMENITIES,
-  CAMPING_TYPES,
-  FACILITIES_OPTIONS,
-  GROUND_TYPES,
-  PET_OPTIONS
-} from "../constants/filterOptions";
-import { REGIONS } from "@/_utils/regions";
-import { CampCard } from "./CampCard";
 import { ActiveFilters } from "./filter/ActiveFilters";
 import { useFilters } from "../hooks/useFilters";
 import SearchHeader from "./SearchHeader";

--- a/src/app/(pages)/search/hooks/useSearchMap.ts
+++ b/src/app/(pages)/search/hooks/useSearchMap.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback } from "react";
+import { useEffect, useCallback } from "react";
 import type { MapOptions, NaverMarker } from "../../../../type/map";
 import { MAP_CONFIG } from "../constants/map";
 import { Camp } from "../../camps/types/Camp";


### PR DESCRIPTION
## 어떤 기능인가요?

> 모임 상세페이지의 지도 구현

## 작업 상세 내용

- [ ] 모임 상세페이지에 캠핑장 지도 표시 기능 구현 완료
- [ ] 캠핑장 기본 정보 표시 구현 완료
- [ ] 사용하지 않는 import 제거

## 기타
- 부대시설(sbrsEtc) 정보 미노출 상태
- 관련 이슈 #57 참조

