### PR TITLE
[feat/pagination] 모임 리스트 페이지네이션 기능 추가

### DIFF
--- a/src/app/(pages)/meets/components/meetsList/MeetsList.tsx
+++ b/src/app/(pages)/meets/components/meetsList/MeetsList.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import MeetCard from "@/_components/meet/MeetCard";
+import { getMeetList } from "../../actions/meetListAction";
+import { MeetWithCamp } from "../../types/meet.types";
+import { convertMeetDataToMeetCard } from "../../utils/convertMeetDataToMeetCard";
+import WriteButton from "../meets/WriteButton";
+import { useQuery } from "@tanstack/react-query";
+import usePagination from "@/_components/pagination/hooks/pagination";
+import Pagination from "@/_components/pagination/Pagination";
+
+type MeetsListProps = {
+  itemsPerPage: number;
+};
+
+const MeetsList = ({ itemsPerPage }: MeetsListProps) => {
+  const { data: meetWithCampList, isError } = useQuery<MeetWithCamp[]>({
+    queryKey: ["meets"],
+    queryFn: async () => getMeetList()
+  });
+
+  const { currentItems, page, totalPages, movePagePrev, movePageNext } =
+    usePagination({ items: meetWithCampList || [], itemsPerPage });
+
+  if (!currentItems) return <>데이터 로딩중.</>;
+
+  const meetCardList = convertMeetDataToMeetCard(currentItems);
+
+  return (
+    <div className="relative mx-auto w-full max-w-[1360px] px-[30px]">
+      <div className="absolute right-[30px] top-4 h-[40px]">
+        <WriteButton>작성으로 가자</WriteButton>
+      </div>
+      <ul className="mt-[40px] flex flex-wrap justify-center gap-[23px]">
+        {meetCardList.map((meetCard) => (
+          <li key={meetCard.id} className="w-[44%]">
+            {" "}
+            {/* 각 아이템을 50% 너비로 설정 */}
+            <MeetCard meetCard={meetCard} />
+          </li>
+        ))}
+      </ul>
+      {/* <ul className="grid grid-cols-3">
+        {meetCardList.map((meetCard) => (
+          <li key={meetCard.id}>
+            <MeetCard meetCard={meetCard} />
+          </li>
+        ))}
+      </ul> */}
+
+      <Pagination
+        page={page}
+        totalPages={totalPages}
+        onMovePagePrev={movePagePrev}
+        onMovePageNext={movePageNext}
+      />
+    </div>
+  );
+};
+
+export default MeetsList;

--- a/src/app/(pages)/meets/page.tsx
+++ b/src/app/(pages)/meets/page.tsx
@@ -1,11 +1,6 @@
 import React from "react";
-import WriteButton from "./components/meets/WriteButton";
-import { MeetWithCamp } from "./types/meet.types";
-import { getMeetList } from "./actions/meetListAction";
 import { Metadata } from "next";
-import MeetCard from "@/_components/meet/MeetCard";
-import { convertMeetDataToMeetCard } from "./utils/convertMeetDataToMeetCard";
-import Link from "next/link";
+import MeetsList from "./components/meetsList/MeetsList";
 
 export async function generateMetadata(): Promise<Metadata> {
   return {
@@ -14,34 +9,6 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-const Meets = async () => {
-  const meetWithCampList: MeetWithCamp[] = await getMeetList();
-
-  const meetCardList = convertMeetDataToMeetCard(meetWithCampList);
-
-  return (
-    <div className="relative mx-auto w-full max-w-[1360px] px-[30px]">
-      <div className="absolute right-[30px] top-4 h-[40px]">
-        <WriteButton>작성으로 가자</WriteButton>
-      </div>
-      <ul className="mt-[40px] flex flex-wrap justify-center gap-[23px]">
-        {meetCardList.map((meetCard) => (
-          <li key={meetCard.id} className="w-[44%]">
-            {" "}
-            {/* 각 아이템을 50% 너비로 설정 */}
-            <MeetCard meetCard={meetCard} />
-          </li>
-        ))}
-      </ul>
-      {/* <ul className="grid grid-cols-3">
-        {meetCardList.map((meetCard) => (
-          <li key={meetCard.id}>
-            <MeetCard meetCard={meetCard} />
-          </li>
-        ))}
-      </ul> */}
-    </div>
-  );
-};
+const Meets = async () => <MeetsList itemsPerPage={6} />;
 
 export default Meets;


### PR DESCRIPTION
## 어떤 기능인가요?

> 기존 서버 컴포넌트에서 사용이 불가하여 클라이언트 컴포넌트 생성 후 페이지네이션 적용

## 작업 상세 내용

- 기존 page.tsx 에서는 서버 컴포넌트여서 `MeetsList.tsx`(클라이언트 컴포넌트)를 사용해줌
- `MeetsList.tsx` 컴포넌트 생성 후 react query와 페이지네이션 커스텀 훅을 사용해서 페이지네이션 처리를 해줬습니다.

## 기타사항
- 없습니다.

## 참고할만한 자료(선택)
- 없습니다.