### PR TITLE
[feat/interaction] 모바일 헤더 및 레이아웃 상단 padding 값 수정

### DIFF
--- a/src/_components/layout/header/Header.tsx
+++ b/src/_components/layout/header/Header.tsx
@@ -102,7 +102,7 @@ const Header = () => {
 
   return (
     <header className="fixed left-0 right-0 top-0 z-[110] bg-white shadow-md">
-      <div className="relative mx-auto w-full max-w-[1360px] bg-white p-3 px-[30px]">
+      <div className="relative mx-auto w-full max-w-[1360px] bg-white p-3 px-[30px] max-767:px-[15px]">
         {/* 메인 헤더 */}
         <div className="z-10 flex items-center justify-between gap-9 leading-40">
           {/* 로고 + 검색 영역 */}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -38,7 +38,7 @@ export default function RootLayout({
                 ></Script>
 
                 <Header />
-                <div className="min-h-[calc(100vh-80px)] pt-[80px]">
+                <div className="min-h-[calc(100vh-80px)] pt-[80px] max-767:pt-[112px]">
                   {children}
                 </div>
                 <Footer />


### PR DESCRIPTION
## 어떤 기능인가요?

> [feat/interaction] 모바일 헤더 및 레이아웃 상단 padding 값 수정
## 작업 상세 내용

- 모바일 헤더 좌우 15px 적용
- 헤더 검색, 태그로 인해 상단 padding-top 모바일에서 수정

## 기타사항
- 없습니다.

## 참고할만한 자료(선택)
- 없습니다.